### PR TITLE
Added config option php_binary

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -25,7 +25,7 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')->end()
                 ->end()
                 ->scalarNode('php_binary')
-                    ->defaultValue(null)
+                    ->defaultValue('php')
                     ->info('Path to PHP binary')
                 ->end()
             ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -24,6 +24,10 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('variables')
                     ->prototype('scalar')->end()
                 ->end()
+                ->scalarNode('php_binary')
+                    ->defaultValue(null)
+                    ->info('Path to PHP binary')
+                ->end()
             ->end()
         ;
 

--- a/Util/Helper.php
+++ b/Util/Helper.php
@@ -34,7 +34,8 @@ class Helper
                     }
 
                     $annotation->commandLine = sprintf(
-                        'php %s %s',
+                        '%s %s %s',
+                        $config['php_binary']?:'php',
                         realpath($_SERVER['argv'][0]),
                         $annotation->commandLine === null ? $command->getName() : $annotation->commandLine
                     );

--- a/Util/Helper.php
+++ b/Util/Helper.php
@@ -35,7 +35,7 @@ class Helper
 
                     $annotation->commandLine = sprintf(
                         '%s %s %s',
-                        $config['php_binary']?:'php',
+                        $config['php_binary'],
                         realpath($_SERVER['argv'][0]),
                         $annotation->commandLine === null ? $command->getName() : $annotation->commandLine
                     );


### PR DESCRIPTION
Added config option to set the path of the php binary put in the generated crontab. 
We needed this to run the cron from a different container than where the crontab is generated from.

```
padam87_cron:
  php_binary: docker exec <container_name> php ....
```