### PR TITLE
feat: php 8 attributes added

### DIFF
--- a/Annotation/Job.php
+++ b/Annotation/Job.php
@@ -2,54 +2,42 @@
 
 namespace Padam87\CronBundle\Annotation;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("CLASS")
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class Job
 {
-    public string $minute = '*';
-    public string $hour = '*';
-    public string $day = '*';
-    public string $month = '*';
-    public string $dayOfWeek = '*';
-
+    public string $minute;
+    public string $hour;
+    public string $day ;
+    public string $month;
+    public string $dayOfWeek;
     public ?string $group = null;
-
     public ?string $logFile = null;
-
     public ?string $commandLine = null;
 
     public function __construct(
-        string|array $minute = '*',
+        string $minute = '*',
         string $hour = '*',
         string $day = '*',
         string $month = '*',
         string $dayOfWeek = '*',
-        string $group = '',
-        string $logFile = '',
+        ?string $group = null,
+        ?string $logFile = null,
         ?string $commandLine = null
     ) {
-        if (is_array($minute)) {
-            // Invocation through annotations with an array parameter only
-            $this->processAttribute($minute);
-        } else {
-            $this->commandLine = $commandLine;
-            $this->minute = $minute;
-            $this->hour = $hour;
-            $this->day = $day;
-            $this->month = $month;
-            $this->dayOfWeek = $dayOfWeek;
-            $this->group = $group;
-            $this->logFile = $logFile;
-        }
-    }
-
-    public function processAttribute(array $attributes): void
-    {
-        foreach ($attributes as $name => $value) {
-            $this->$name = $value;
-        }
+        $this->minute = $minute;
+        $this->hour = $hour;
+        $this->day = $day;
+        $this->month = $month;
+        $this->dayOfWeek = $dayOfWeek;
+        $this->group = $group;
+        $this->logFile = $logFile;
+        $this->commandLine = $commandLine;
     }
 }

--- a/Annotation/Job.php
+++ b/Annotation/Job.php
@@ -6,45 +6,50 @@ namespace Padam87\CronBundle\Annotation;
  * @Annotation
  * @Target("CLASS")
  */
+#[\Attribute(\Attribute::TARGET_CLASS)]
 class Job
 {
-    /**
-     * @var string
-     */
-    public $minute = '*';
+    public string $minute = '*';
+    public string $hour = '*';
+    public string $day = '*';
+    public string $month = '*';
+    public string $dayOfWeek = '*';
 
-    /**
-     * @var string
-     */
-    public $hour = '*';
+    public ?string $group = null;
 
-    /**
-     * @var string
-     */
-    public $day = '*';
+    public ?string $logFile = null;
 
-    /**
-     * @var string
-     */
-    public $month = '*';
+    public ?string $commandLine = null;
 
-    /**
-     * @var string
-     */
-    public $dayOfWeek = '*';
+    public function __construct(
+        string|array $minute = '*',
+        string $hour = '*',
+        string $day = '*',
+        string $month = '*',
+        string $dayOfWeek = '*',
+        string $group = '',
+        string $logFile = '',
+        ?string $commandLine = null
+    ) {
+        if (is_array($minute)) {
+            // Invocation through annotations with an array parameter only
+            $this->processAttribute($minute);
+        } else {
+            $this->commandLine = $commandLine;
+            $this->minute = $minute;
+            $this->hour = $hour;
+            $this->day = $day;
+            $this->month = $month;
+            $this->dayOfWeek = $dayOfWeek;
+            $this->group = $group;
+            $this->logFile = $logFile;
+        }
+    }
 
-    /**
-     * @var string
-     */
-    public $commandLine;
-
-    /**
-     * @var string
-     */
-    public $group;
-
-    /**
-     * @var string
-     */
-    public $logFile;
+    public function processAttribute(array $attributes): void
+    {
+        foreach ($attributes as $name => $value) {
+            $this->$name = $value;
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ A simple bundle install. No extra stuff.
 
 ```yaml
 padam87_cron:
-    log_dir: %cron_log_dir%
-    variables:
-        mailto: %cron_mailto%
-        any_other_variable_you_might_need: 'some_value'
+  log_dir: %cron_log_dir%
+  variables:
+    mailto: %cron_mailto%
+    any_other_variable_you_might_need: 'some_value'
 ```
 
 ## Usage
@@ -28,6 +28,13 @@ padam87_cron:
 
 ### Basic
 
+_Using attributes (requires PHP 8.0 or higher)_
+```php
+#[Job(minute: '5', hour: '0')]
+class MyCommand extends Command
+```
+
+_Using annotations_
 ```php
 /**
  * @Cron\Job(minute="5", hour="0")
@@ -37,6 +44,13 @@ class MyCommand extends Command
 
 ### Groups
 
+_Using attributes (requires PHP 8.0 or higher)_
+```php
+#[Job(minute: '5',hour: '0', group: 'master')]
+class MyCommand extends Command
+```
+
+_Using annotations_
 ```php
 /**
  * @Cron\Job(minute="5", hour="0", group="master")
@@ -45,10 +59,18 @@ class MyCommand extends Command
 ```
 
 ### Output file
+_Using attributes (requires PHP 8.0 or higher)_
+```php
+#[Job(minute: '5', hour: '0', logFile: 'my-command.log')]
+class MyCommand extends Command
+```
 
+_Using annotations_
 ```php
 /**
  * @Cron\Job(minute="5", hour="0", logFile="my-command.log")
  */
 class MyCommand extends Command
 ```
+
+

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "psr-4": {"Padam87\\CronBundle\\": ""}
     },
     "require": {
-        "php": "^7.1|^8.0",
-        "doctrine/annotations": "~1.0",
+        "php": "^7.4",
+        "doctrine/annotations": "^1.12",
         "symfony/console": "^5.1|^6.0",
         "symfony/process": "^5.1|^6.0",
         "symfony/config": "^5.1|^6.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "psr-4": {"Padam87\\CronBundle\\": ""}
     },
     "require": {
-        "php": "^7.4",
+        "php": "^7.4|^8.0",
         "doctrine/annotations": "^1.12",
         "symfony/console": "^5.1|^6.0",
         "symfony/process": "^5.1|^6.0",


### PR DESCRIPTION
I've created attributes for php 8.

Since this bundle is only used by users who are running php 7.4 or higher i've decided to update the composer.json to the minum version of php 7.4.
source: https://packagist.org/packages/padam87/cron-bundle/php-stats

When people are using php 7.4 they can still make use of the annotations.

Also I've updated the README so people are aware that this bundle does make usage of attributes.
