### PR TITLE
fix: `commandLine` parameter was not used

### DIFF
--- a/Tests/HelperTest.php
+++ b/Tests/HelperTest.php
@@ -112,7 +112,7 @@ class HelperTest extends TestCase
     /**
      * @test
      */
-    public function should_process_jobs()
+    public function should_process_job_parameters()
     {
         $commands = [new ProcessTestCommand()];
 
@@ -129,8 +129,14 @@ class HelperTest extends TestCase
 
         $job = $tab->getJobs()[0];
 
+        // groups parameter
+        $this->assertEquals('my-group', $job->group);
+
+        // logFile parameter
         $this->assertEquals($this->getConfig()['log_dir'] . '/myjob.log', $job->logFile);
+
+        // commandLine parameter
         $this->assertStringStartsWith($this->getConfig()['php_binary'], $job->commandLine);
-        $this->assertStringEndsWith('my:job', $job->commandLine);
+        $this->assertStringEndsWith('my:job 42 --first-option --second-option true', $job->commandLine);
     }
 }

--- a/Tests/Resources/Command/ProcessTestCommand.php
+++ b/Tests/Resources/Command/ProcessTestCommand.php
@@ -5,7 +5,7 @@ namespace Padam87\CronBundle\Tests\Resources\Command;
 use Padam87\CronBundle\Attribute\Job;
 use Symfony\Component\Console\Command\Command;
 
-#[Job(logFile: 'myjob.log')]
+#[Job(group: 'my-group', logFile: 'myjob.log', commandLine: 'my:job 42 --first-option --second-option true')]
 class ProcessTestCommand extends Command
 {
     protected static $defaultName = 'my:job';

--- a/Util/Helper.php
+++ b/Util/Helper.php
@@ -63,7 +63,7 @@ class Helper
             '%s %s %s',
             $config['php_binary'],
             realpath($_SERVER['argv'][0]),
-            $annotation->commandLine ?? $commandInstance->getName()
+            $job->commandLine ?? $commandInstance->getName()
         );
 
         if ($config['log_dir'] !== null && $job->logFile !== null) {


### PR DESCRIPTION
In this code:
```php
#[Job(commandLine: 'my:job 42')]
```

The `commandLine` parameter was ignored, and the code would default to the command name (`my:job` in this case). 